### PR TITLE
Add caching

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,4 @@
+const ms = require('ms');
 const withNextIntl = require('next-intl/plugin')();
 
 /** @type {import('next').NextConfig} */
@@ -12,6 +13,28 @@ const nextConfig = {
         hostname: 'images.unsplash.com'
       }
     ]
+  },
+  headers() {
+    return [
+      {
+        source: '/((?!_next|favicon.ico).*)',
+        missing: [
+          {
+            type: 'header',
+            key: 'Next-Router-Prefetch'
+          }
+        ],
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: [
+              `s-maxage=` + ms('1d') / 1000,
+              `stale-while-revalidate=` + ms('1y') / 1000
+            ].join(', ')
+          }
+        ]
+      }
+    ];
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@heroicons/react": "^2.0.14",
     "@next/font": "13.1.5",
     "clsx": "^1.2.1",
+    "ms": "2.1.3",
     "next": "13.2.3",
     "next-intl": "^2.11.0-beta.10",
     "react": "18.2.0",

--- a/src/app/[locale]/Pagination.tsx
+++ b/src/app/[locale]/Pagination.tsx
@@ -22,15 +22,10 @@ export default function Pagination({pageInfo, orderBy}: Props) {
     };
   }
 
-  // Vercel currently doesn't support the `vary` header which is used to
-  // differentiate prefetch requests, therefore manually opt-out of these.
-  // https://github.com/vercel/vercel/discussions/7612#discussioncomment-2434736
-  const prefetch = false;
-
   return (
     <div className="flex items-center gap-3 py-8">
       {pageInfo.page > 1 && (
-        <Link aria-label={t('prev')} href={getHref(pageInfo.page - 1)} prefetch={prefetch}>
+        <Link aria-label={t('prev')} href={getHref(pageInfo.page - 1)}>
           <ArrowLeftIcon height={24} />
         </Link>
       )}
@@ -38,7 +33,7 @@ export default function Pagination({pageInfo, orderBy}: Props) {
         {t('info', {...pageInfo, totalPages})}
       </Text>
       {pageInfo.page < totalPages && (
-        <Link aria-label={t('prev')} href={getHref(pageInfo.page + 1)} prefetch={prefetch}>
+        <Link aria-label={t('prev')} href={getHref(pageInfo.page + 1)}>
           <ArrowRightIcon height={24} />
         </Link>
       )}

--- a/src/app/[locale]/Pagination.tsx
+++ b/src/app/[locale]/Pagination.tsx
@@ -22,10 +22,15 @@ export default function Pagination({pageInfo, orderBy}: Props) {
     };
   }
 
+  // Vercel currently doesn't support the `vary` header which is used to
+  // differentiate prefetch requests, therefore manually opt-out of these.
+  // https://github.com/vercel/vercel/discussions/7612#discussioncomment-2434736
+  const prefetch = false;
+
   return (
     <div className="flex items-center gap-3 py-8">
       {pageInfo.page > 1 && (
-        <Link aria-label={t('prev')} href={getHref(pageInfo.page - 1)}>
+        <Link aria-label={t('prev')} href={getHref(pageInfo.page - 1)} prefetch={prefetch}>
           <ArrowLeftIcon height={24} />
         </Link>
       )}
@@ -33,7 +38,7 @@ export default function Pagination({pageInfo, orderBy}: Props) {
         {t('info', {...pageInfo, totalPages})}
       </Text>
       {pageInfo.page < totalPages && (
-        <Link aria-label={t('prev')} href={getHref(pageInfo.page + 1)}>
+        <Link aria-label={t('prev')} href={getHref(pageInfo.page + 1)} prefetch={prefetch}>
           <ArrowRightIcon height={24} />
         </Link>
       )}

--- a/src/middleware.tsx
+++ b/src/middleware.tsx
@@ -1,25 +1,9 @@
-import ms from 'ms';
 import createIntlMiddleware from 'next-intl/middleware';
-import {NextRequest} from 'next/server';
 
-const middleware = createIntlMiddleware({
+export default createIntlMiddleware({
   locales: ['en', 'es'],
   defaultLocale: 'en'
 });
-
-export default function handler(req: NextRequest) {
-  const response = middleware(req);
-
-  response.headers.set(
-    'Cache-Control',
-    [
-      `s-maxage=` + ms('1d') / 1000,
-      `stale-while-revalidate=` + ms('1y') / 1000
-    ].join(', ')
-  );
-
-  return response;
-}
 
 export const config = {
   // Skip all non-content paths

--- a/src/middleware.tsx
+++ b/src/middleware.tsx
@@ -10,6 +10,13 @@ const middleware = createIntlMiddleware({
 export default function handler(req: NextRequest) {
   const response = middleware(req);
 
+  // Vercel currently doesn't support the `vary` header which is used to
+  // differentiate prefetch requests, therefore manually opt-out of these.
+  // https://github.com/vercel/vercel/discussions/7612#discussioncomment-2434736
+  if (req.headers.has('x-next-prefetch')) {
+    return response;
+  }
+  
   response.headers.set(
     'Cache-Control',
     [

--- a/src/middleware.tsx
+++ b/src/middleware.tsx
@@ -10,13 +10,6 @@ const middleware = createIntlMiddleware({
 export default function handler(req: NextRequest) {
   const response = middleware(req);
 
-  // Vercel currently doesn't support the `vary` header which is used to
-  // differentiate prefetch requests, therefore manually opt-out of these.
-  // https://github.com/vercel/vercel/discussions/7612#discussioncomment-2434736
-  if (req.headers.has('x-next-prefetch')) {
-    return response;
-  }
-  
   response.headers.set(
     'Cache-Control',
     [

--- a/src/middleware.tsx
+++ b/src/middleware.tsx
@@ -1,11 +1,27 @@
+import ms from 'ms';
 import createIntlMiddleware from 'next-intl/middleware';
+import {NextRequest} from 'next/server';
 
-export default createIntlMiddleware({
+const middleware = createIntlMiddleware({
   locales: ['en', 'es'],
   defaultLocale: 'en'
 });
 
+export default function handler(req: NextRequest) {
+  const response = middleware(req);
+
+  response.headers.set(
+    'Cache-Control',
+    [
+      `s-maxage=` + ms('1d') / 1000,
+      `stale-while-revalidate=` + ms('1y') / 1000
+    ].join(', ')
+  );
+
+  return response;
+}
+
 export const config = {
-  // Skip all internal paths
-  matcher: ['/((?!_next).*)']
+  // Skip all non-content paths
+  matcher: ['/((?!_next|favicon.ico).*)']
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1779,7 +1779,7 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
-ms@^2.1.1:
+ms@2.1.3, ms@^2.1.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==


### PR DESCRIPTION
Vercel [currently doesn't support the Vary header](https://github.com/vercel/vercel/discussions/7612#discussioncomment-2434736), therefore RSC prefetch requests return the same response as the actual transition request. This breaks navigation.